### PR TITLE
updated broom button positioning when cosmos db is enabled

### DIFF
--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -930,8 +930,8 @@ const Chat = () => {
                       ? styles.clearChatBroom
                       : styles.clearChatBroomNoCosmos
                   }
-                  //update broom position to align it with textfield
-                  style={{top:linesRef>5?`${Math.min(200, linesRef * 20)-30}px`:'80px'}}
+                  //update broom position to align it with textfield if no cosmos db is used
+                  // style={{top:linesRef>5?`${Math.min(200, linesRef * 20)-30}px`:'80px'}}
                   iconProps={{ iconName: 'Broom' }}
                   onClick={
                     appStateContext?.state.isCosmosDBAvailable?.status !== CosmosDBStatus.NotConfigured


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to this repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? 
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
  5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app.
-->

The broom button positioning was not correct. I have fixed that.
Before-
<img width="674" alt="image" src="https://github.com/user-attachments/assets/b4a4d684-04cb-4d95-913a-08b820520d9a" />

After-
<img width="707" alt="image" src="https://github.com/user-attachments/assets/0a24ae02-8d77-4c24-801b-14e3ccfbe307" />


### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
     There was a customized styling for Broom Button. It worked fine when Cosmos DB was disabled. As enabling Cosmos DB adds a new button (Add Chat Button), the customized styling had to be removed.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [ ] I didn't break any existing functionality :smile:
